### PR TITLE
add handler for deregistering sensu clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- added sensu-deregister handler for deregistering a sensu client upon request (see https://github.com/sensu/sensu-build/pull/148 for example).
 
 ## [0.0.2] - 2015-07-14
 ### Changed

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-handler'
+
+class Deregister < Sensu::Handler
+  def handle
+    delete_sensu_client!
+  end
+
+  def delete_sensu_client!
+    response = api_request(:DELETE, '/clients/' + @event['client']['name']).code
+    deletion_status(response)
+  end
+
+  def deletion_status(code)
+    case code
+    when '202'
+      puts "202: Successfully deleted Sensu client: #{@event['client']['name']}"
+    when '404'
+      puts "404: Unable to delete #{@event['client']['name']}, doesn't exist!"
+    when '500'
+      puts "500: Miscellaneous error when deleting #{@event['client']['name']}"
+    else
+      puts "#{res}: Completely unsure of what happened!"
+    end
+  end
+end

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'rubygems'
 require 'sensu-handler'
 
 class Deregister < Sensu::Handler


### PR DESCRIPTION
Events passed to this handler will cause the corresponding client to be deleted via the Sensu API. Intended for use with new `CLIENT_DEREGISTER_ON_STOP` and `CLIENT_DEREGISTER_HANDLER` variables in the sensu-service init script (see https://github.com/sensu/sensu-build/pull/148).
