### PR TITLE
Adding misconfiguration check, honor stashed checks, summerize output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- check-aggregates.rb adding misconfiguration check to 
+- check-aggregates.rb If summarize is set and the threshold output is being used the alert will be the summarized results
+- check-aggregates.rb Added new flag to honor stashed checks. If -i is supplied and the threshold alert is being used it will remove any checks that are stashed
 
 [0.1.0] - 2016-01-08
 ### Added

--- a/Rakefile
+++ b/Rakefile
@@ -8,15 +8,15 @@ require 'yard/rake/yardoc_task'
 
 desc 'Don\'t run Rubocop for unsupported versions'
 begin
-  if RUBY_VERSION >= '2.0.0'
-    args = [:spec, :make_bin_executable, :yard, :rubocop]
-  else
-    args = [:spec, :make_bin_executable, :yard]
-  end
+  args = if RUBY_VERSION >= '2.0.0'
+           [:spec, :make_bin_executable, :yard, :rubocop]
+         else
+           [:spec, :make_bin_executable, :yard]
+         end
 end
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w()
+  OTHER_PATHS = %w().freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
   t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md,CONTRIBUTING.md)
 end

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -119,7 +119,7 @@ class Remediator < Sensu::Handler
                   when value.to_s =~ /^(\d+)-(\d+)$/ && Range.new($LAST_MATCH_INFO.to_a[1].to_i, $LAST_MATCH_INFO.to_a[2].to_i).to_a.include?(occurrences) then true # rubocop:disable LineLength
                   when value.to_s.match(/^(\d+)\+$/) && Range.new($LAST_MATCH_INFO.to_a[1].to_i, 9999).include?(occurrences) then true
                   else false
-        end
+                  end
         break if trigger
       end
 

--- a/bin/metrics-delete-expired-stashes.rb
+++ b/bin/metrics-delete-expired-stashes.rb
@@ -57,7 +57,11 @@ class CheckSilenced < Sensu::Plugin::Metric::CLI::Graphite
 
   def api
     endpoint = URI.parse("http://#{@config[:host]}:#{@config[:port]}")
-    @config[:use_ssl?] ? endpoint.scheme = 'https' : endpoint.scheme = 'http'
+    endpoint.scheme = if @config[:use_ssl?]
+                        'https'
+                      else
+                        'http'
+                      end
     @api ||= RestClient::Resource.new(endpoint, timeout: 45)
   end
 
@@ -65,7 +69,7 @@ class CheckSilenced < Sensu::Plugin::Metric::CLI::Graphite
     all_stashes = JSON.parse(api['/stashes'].get)
     filtered_stashes = []
     all_stashes.each do |stash|
-      filtered_stashes << stash if stash['path'].match(/^#{@config[:filter]}\/.*/)
+      filtered_stashes << stash if stash['path'] =~ /^#{@config[:filter]}\/.*/
     end
     return filtered_stashes
   rescue Errno::ECONNREFUSED

--- a/sensu-plugins-sensu.gemspec
+++ b/sensu-plugins-sensu.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
   s.required_ruby_version  = '>= 1.9.3'
-  s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
+  s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME.end_with?('gem')
   s.summary                = 'Sensu plugins for sensu'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsSensu::Version::VER_STRING


### PR DESCRIPTION
- The plugin will currently respond with an `ok` if it's misconfigured this ensures that critical || warning || (summarize && pattern) are set and alerts if they are not properly configured
- If summarize is set and the threshold output is being used the alert will be the summarized results
- Added new flag to honor stashed checks.  If -i is supplied and the threshold alert is being used it will remove any checks that are stashed.
