### PR TITLE
Remove api_call event in deregister handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-aggregates.rb Adding -k for https insecure mode
 - check-aggregates.rb Added config option to use environment var SENSU_API=hostname or SENSU_API_URL=hostname:port for -a 
 - check-aggregates.rb Added ability to use node down count instead of percentages
+- handler-sensu-deregister.rb Remove api_call event
 
 ## [0.1.0] - 2016-01-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-aggregates.rb Adding -k for https insecure mode
 - check-aggregates.rb Added config option to use environment var SENSU_API=hostname or SENSU_API_URL=hostname:port for -a 
 - check-aggregates.rb Added ability to use node down count instead of percentages
-- handler-sensu-deregister.rb Remove api_call event
+- handler-sensu-deregister.rb Removed api_call event
 
 ## [0.1.0] - 2016-01-08
 ### Added

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -15,7 +15,7 @@ class Deregister < Sensu::Handler
   end
 
   def delete_sensu_event!
-    response = api_request(:DELETE, '/events/' + @event['client']['name'] + '/api_call').code
+    api_request(:DELETE, '/events/' + @event['client']['name'] + '/api_call')
   end
 
   def deletion_status(code)

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -6,11 +6,16 @@ require 'sensu-handler'
 class Deregister < Sensu::Handler
   def handle
     delete_sensu_client!
+    delete_sensu_event!
   end
 
   def delete_sensu_client!
     response = api_request(:DELETE, '/clients/' + @event['client']['name']).code
     deletion_status(response)
+  end
+
+  def delete_sensu_event!
+    response = api_request(:DELETE, '/events/' + @event['client']['name'] + '/api_call').code
   end
 
   def deletion_status(code)


### PR DESCRIPTION
## Pull Request Checklist

no
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Otherwise the event list gets bigger and bigger...
