### PR TITLE
Disable filtering in handler-sensu-deregister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-aggregates.rb Adding -k for https insecure mode
 - check-aggregates.rb Added config option to use environment var SENSU_API=hostname or SENSU_API_URL=hostname:port for -a 
 - check-aggregates.rb Added ability to use node down count instead of percentages
+- handler-sensu-deregister.rb Disabling default `filter` behavior, as many folks have complained of deregistration events being filtered.
 
 ## [0.1.0] - 2016-01-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-aggregates.rb Adding -k for https insecure mode
 - check-aggregates.rb Added config option to use environment var SENSU_API=hostname or SENSU_API_URL=hostname:port for -a 
 - check-aggregates.rb Added ability to use node down count instead of percentages
-- handler-sensu-deregister.rb Disabling default `filter` behavior, as many folks have complained of deregistration events being filtered.
+- handler-sensu-deregister.rb: Overrode sensu-plugin's default `filter` method to make it a noop; deregistration events are one-time and shouldn't be filtered.
 
 ## [0.1.0] - 2016-01-08
 ### Added

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -25,4 +25,8 @@ class Deregister < Sensu::Handler
       puts "#{res}: Completely unsure of what happened!"
     end
   end
+
+  def filter
+    # override filter method to disable filtering of deregistration events
+  end
 end


### PR DESCRIPTION
## Pull Request Checklist

The following issues relate to existing problems with the deregistration event/handler:
- https://github.com/sensu/sensu-build/issues/162
- https://github.com/sensu/sensu-build/pull/148#issuecomment-218370362
- https://github.com/sensu-plugins/sensu-plugins-sensu/issues/3
- https://github.com/sensu-plugins/sensu-plugins-sensu/issues/7
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

Following the introduction of optional client reregistration circa Sensu 0.23, we've seen a number of issues reported where deregistration events are unexpectedly filtered. 

In  sensu/sensu#1315 (released in Sensu 0.25) the deregistration behavior moved out of the init scripts and into the client process itself, which should help us to avoid race conditions that have prompted other issues (e.g. https://github.com/sensu-plugins/sensu-plugins-sensu/issues/7, potentially https://github.com/sensu-plugins/sensu-plugins-sensu/issues/3).  

It's been suggested that deregistration events should be configured with `occurrences` and `refresh` both set to `1`, but in light of the feedback on sensu/sensu#1315 and the [proposed deprecation and removal of filtering in sensu-plugin library itself](https://github.com/sensu-plugins/sensu-plugin/issues/134) I think it makes sense to disable filtering altogether in this handler.
#### Known Compatablity Issues

None.
