### PR TITLE
Update check-aggregate.rb to support honor-stash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-aggregates.rb: Fixed ability to honor-stashed in Sensu 0.24
 
 ## [1.0.0] - 2016-07-13
 ### Added

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -185,11 +185,11 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
   def named_aggregate_results
     results = api_request("/aggregates/#{config[:check]}?max_age=#{config[:age]}")[:results]
     warning "No aggregates found in last #{config[:age]} seconds" if %w(ok warning critical unknown).all? { |x| results[x.to_sym] == 0 }
-    
+
     err_results = []
     if results[:critical] > 0
       critical_errors = api_request("/aggregates/#{config[:check]}/results/critical")
-      critical_errors.each do |error| 
+      critical_errors.each do |error|
         error[:status] = 2
       end
       err_results.concat(critical_errors)
@@ -197,7 +197,7 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     if results[:warning] > 0
       warnings = api_request("/aggregates/#{config[:check]}/results/warning")
       warnings.each do |error| 
-         error[:status] = 1
+        error[:status] = 1
       end
       err_results.concat(warnings)
     end
@@ -210,7 +210,7 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
         end
       end
     end
-    
+
     results
   end
 

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -196,7 +196,7 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     end
     if results[:warning] > 0
       warnings = api_request("/aggregates/#{config[:check]}/results/warning")
-      warnings.each do |error| 
+      warnings.each do |error|
         error[:status] = 1
       end
       err_results.concat(warnings)

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -189,20 +189,24 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     err_results = []
     if results[:critical] > 0
       critical_errors = api_request("/aggregates/#{config[:check]}/results/critical")
-      critical_errors.each {|x| x[:status] = 2 }
+      critical_errors.each do |error| 
+        error[:status] = 2
+      end
       err_results.concat(critical_errors)
     end
     if results[:warning] > 0
       warnings = api_request("/aggregates/#{config[:check]}/results/warning")
-      warnings.each {|x| x[:status] = 1 }
+      warnings.each do |error| 
+         error[:status] = 1
+      end
       err_results.concat(warnings)
     end
 
     results[:results] = []
-    for result in err_results
-      for summary in result[:summary]
-        for client in summary[:clients]
-          results[:results].push({:check=>result[:check], :client=>client, :status=>result[:status]})
+    err_results.each do |result|
+      result[:summary].each do |summary|
+        summary[:clients].each do |client|
+          results[:results].push(check: result[:check], client: client, status: result[:status])
         end
       end
     end

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -185,6 +185,28 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
   def named_aggregate_results
     results = api_request("/aggregates/#{config[:check]}?max_age=#{config[:age]}")[:results]
     warning "No aggregates found in last #{config[:age]} seconds" if %w(ok warning critical unknown).all? { |x| results[x.to_sym] == 0 }
+    
+    err_results = []
+    if results[:critical] > 0
+      critical_errors = api_request("/aggregates/#{config[:check]}/results/critical")
+      critical_errors.each {|x| x[:status] = 2 }
+      err_results.concat(critical_errors)
+    end
+    if results[:warning] > 0
+      warnings = api_request("/aggregates/#{config[:check]}/results/warning")
+      warnings.each {|x| x[:status] = 1 }
+      err_results.concat(warnings)
+    end
+
+    results[:results] = []
+    for result in err_results
+      for summary in result[:summary]
+        for client in summary[:clients]
+          results[:results].push({:check=>result[:check], :client=>client, :status=>result[:status]})
+        end
+      end
+    end
+    
     results
   end
 


### PR DESCRIPTION
## Pull Request Checklist
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
#### Purpose

The honor-stash function needs a list of maps with check/client/status information. This change includes the queries to add that information to when calling the named_aggregate_results function.

I'm not a very experienced ruby programmer so feel free to reject and treat this as a bug report.
