### PR TITLE
[WIP] Fix collect_output in check-aggregate.rb

### DIFF
--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -187,7 +187,8 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
         output << entry[:output] + "\n" unless entry[:status] == 0
       end
     end
-    aggregate[:outputs] = [output]
+    aggregate[:outputs] = output unless output.empty?
+    aggregate
   end
 
   def acquire_aggregate
@@ -225,15 +226,9 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
 
   def compare_thresholds(aggregate)
     percent_non_zero = (100 - (aggregate[:ok].to_f / aggregate[:total].to_f) * 100).to_i
-    message = ''
-    if aggregate[:outputs]
-      aggregate[:outputs].each do |output, count|
-        message << "\n" + output.to_s if count == 1
-      end
-    else
-      message = config[:message] || 'Number of non-zero results exceeds threshold'
-      message += " (#{percent_non_zero}% non-zero)"
-    end
+    message = config[:message] || 'Number of non-zero results exceeds threshold'
+    message += " (#{percent_non_zero}% non-zero)"
+    message += "\n" + aggregate[:outputs] if aggregate[:outputs]
 
     if config[:critical] && percent_non_zero >= config[:critical]
       critical message

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -258,15 +258,9 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
 
   def compare_thresholds_count(aggregate)
     number_of_nodes_reporting_down = aggregate[:total].to_i - aggregate[:ok].to_i
-    message = ''
-    if aggregate[:outputs]
-      aggregate[:outputs].each do |output, count|
-        message << "\n" + output.to_s if count == 1
-      end
-    else
-      message = config[:message] || 'Number of nodes down exceeds threshold'
-      message += " (#{number_of_nodes_reporting_down} out of #{aggregate[:total]} nodes reporting not ok)"
-    end
+    message = config[:message] || 'Number of nodes down exceeds threshold'
+    message += " (#{number_of_nodes_reporting_down} out of #{aggregate[:total]} nodes reporting not ok)"
+    message += "\n" + aggregate[:outputs] if aggregate[:outputs]
 
     if config[:critical_count] && number_of_nodes_reporting_down >= config[:critical_count]
       critical message


### PR DESCRIPTION
## Pull Request Checklist

It's related to: #19

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Trying to fix `--output` option to work with [named aggregates](https://sensuapp.org/docs/0.26/reference/aggregates.html).

#### Known Compatablity Issues

I've tried to make this change compatible with both sensu 0.23 and `=> 0.24.0` but I think the API changes are to big to maintain compatibility.
I'll cleanup the conditionals that are meant to provide compatibility with 0.23.