### PR TITLE
update the aggregate metric to the latest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- metrics-aggregates.rb: Refactored to support new named aggregates introduced in Sensu 0.24
 
 ## [1.0.0] - 2016-07-13
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

The old aggregate metrics doesnt work with pre 0.24 and named aggregates introduced later which was fixed by this script.

#### Known Compatablity Issues

Not compatible with sensu-api older than 0.24


