### PR TITLE
Add support for client invalidation in the deregister handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Add support for client invalidation on deregister handler
 - handler-sensu-deregister.rb: Fix undefined variable in case of API error.
 
 ## [1.0.0] - 2016-07-13

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -4,12 +4,28 @@ require 'rubygems'
 require 'sensu-handler'
 
 class Deregister < Sensu::Handler
+  option :invalidate,
+         description: 'Invalidate Client',
+         short: '-i',
+         long: '--invalidate',
+         default: false
+
+  option :invalidate_expire,
+         description: 'Invalidate Duration (seconds)',
+         short: '-d duration',
+         long: '--duration duration',
+         required: false
+
   def handle
     delete_sensu_client!
   end
 
   def delete_sensu_client!
-    response = api_request(:DELETE, '/clients/' + @event['client']['name']).code
+    if config[:invalidate] && config[:invalidate_expire]
+      response = api_request(:DELETE, '/clients/' + @event['client']['name'] + "?invalidate=#{config[:invalidate]}&#{config[:invalidate_expire]}").code
+    else
+      response = api_request(:DELETE, '/clients/' + @event['client']['name'] + "?invalidate=#{config[:invalidate]}").code
+    end
     deletion_status(response)
   end
 

--- a/bin/handler-sensu-deregister.rb
+++ b/bin/handler-sensu-deregister.rb
@@ -23,8 +23,10 @@ class Deregister < Sensu::Handler
   def delete_sensu_client!
     if config[:invalidate] && config[:invalidate_expire]
       response = api_request(:DELETE, '/clients/' + @event['client']['name'] + "?invalidate=#{config[:invalidate]}&#{config[:invalidate_expire]}").code
-    else
+    elsif config[:invalidate]
       response = api_request(:DELETE, '/clients/' + @event['client']['name'] + "?invalidate=#{config[:invalidate]}").code
+    else
+      response = api_request(:DELETE, '/clients/' + @event['client']['name']).code
     end
     deletion_status(response)
   end


### PR DESCRIPTION
## Pull Request Checklist

Add CLI options to deregister handler to set invalidate & invalidate_duration parameters.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

In the upcoming 0.29 Sensu Core release deleting a client via the API will provide additional parameters to invalidate a clients results until it is successfully deleted from the registry, or invalidate a client results until a specified duration has passed -- See https://github.com/sensu/sensu/pull/1640

To make use of this functionality when the release is out the deregister handler needs a method to expose those options.

#### Known Compatablity Issues

This is backwards compatible with Sensu <0.29 as the additional URL parameters are simply ignored.