### PR TITLE
Add ignore-severity option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 - handler-sensu-deregister.rb: Fix undefined variable in case of API error.
+- check-aggregates.rb: Changed the default behaviour to alert with the severity of the aggregated checks.
+- check-aggregates.rb: Added new flag to ignore severities. If --ignore-severity is supplied all non-ok will count for critical, critical_count, warning and warning_count option.
 
 ## [1.0.0] - 2016-07-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- handler-sensu-deregister.rb: Fix undefined variable in case of API error.
+### Breaking Changes
 - check-aggregates.rb: Changed the default behaviour to alert with the severity of the aggregated checks.
+
+### Added
 - check-aggregates.rb: Added new flag to ignore severities. If --ignore-severity is supplied all non-ok will count for critical, critical_count, warning and warning_count option.
+
+### Fixed
+- handler-sensu-deregister.rb: Fix undefined variable in case of API error.
 
 ## [1.0.0] - 2016-07-13
 ### Added

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -221,17 +221,17 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     if config[:ignore_severity]
       percent_non_zero = (100 - (aggregate[:ok].to_f / aggregate[:total].to_f) * 100).to_i
       if config[:critical] && percent_non_zero >= config[:critical]
-        critical message % [percent_non_zero, 'non-zero']
+        critical format(message, percent_non_zero, 'non-zero')
       elsif config[:warning] && percent_non_zero >= config[:warning]
-        warning message % [percent_non_zero, 'non-zero']
+        warning format(message, percent_non_zero, 'non-zero')
       end
     else
       percent_warning = (aggregate[:warning].to_f / aggregate[:total].to_f * 100).to_i
       percent_critical = (aggregate[:critical].to_f / aggregate[:total].to_f * 100).to_i
       if config[:critical] && percent_critical >= config[:critical]
-        critical message % [percent_critical, 'critical']
+        critical format(message, percent_critical, 'critical')
       elsif config[:warning] && percent_warning >= config[:warning]
-        warning message % [percent_warning, 'warning']
+        warning format(message, percent_warning, 'warning')
       end
     end
   end
@@ -263,18 +263,18 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     if config[:ignore_severity]
       number_of_nodes_reporting_down = aggregate[:total].to_i - aggregate[:ok].to_i
       if config[:critical_count] && number_of_nodes_reporting_down>= config[:critical_count]
-        critical message % [number_of_nodes_reporting_down, 'not ok']
+        critical format(message, number_of_nodes_reporting_down, 'not ok')
       elsif config[:warning_count] && number_of_nodes_reporting_down >= config[:warning_count]
-        warning message % [number_of_nodes_reporting_down, 'not ok']
+        warning format(message, number_of_nodes_reporting_down, 'not ok')
       end
     else
       nodes_reporting_warning = aggregate[:warning].to_i
       nodes_reporting_critical = aggregate[:critical].to_i
 
       if config[:critical_count] && nodes_reporting_critical >= config[:critical_count]
-        critical message % [nodes_reporting_critical, 'critical']
+        critical format(message, nodes_reporting_critical, 'critical')
       elsif config[:warning_count] && nodes_reporting_warning >= config[:warning_count]
-        warning message % [nodes_reporting_warning, 'warning']
+        warning format(message, nodes_reporting_warning, 'warning')
       end
     end
   end

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -262,7 +262,7 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
 
     if config[:ignore_severity]
       number_of_nodes_reporting_down = aggregate[:total].to_i - aggregate[:ok].to_i
-      if config[:critical_count] && number_of_nodes_reporting_down>= config[:critical_count]
+      if config[:critical_count] && number_of_nodes_reporting_down >= config[:critical_count]
         critical format(message, number_of_nodes_reporting_down, 'not ok')
       elsif config[:warning_count] && number_of_nodes_reporting_down >= config[:warning_count]
         warning format(message, number_of_nodes_reporting_down, 'not ok')

--- a/bin/check-aggregate.rb
+++ b/bin/check-aggregate.rb
@@ -88,23 +88,23 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
   option :warning,
          short: '-W PERCENT',
          long: '--warning PERCENT',
-         description: 'PERCENT non-ok before warning',
+         description: 'PERCENT warning before warning (can be change with --ignore-severity)',
          proc: proc(&:to_i)
 
   option :warning_count,
          long: '--warning_count INTEGER',
-         description: 'number of nodes in warning before warning',
+         description: 'number of nodes in warning before warning (can be change with --ignore-severity)',
          proc: proc(&:to_i)
 
   option :critical,
          short: '-C PERCENT',
          long: '--critical PERCENT',
-         description: 'PERCENT non-ok before critical',
+         description: 'PERCENT critical before critical (can be change with --ignore-severity)',
          proc: proc(&:to_i)
 
   option :critical_count,
          long: '--critical_count INTEGER',
-         description: 'number of node in critical before critical',
+         description: 'number of node in critical before critical (can be change with --ignore-severity)',
          proc: proc(&:to_i)
 
   option :pattern,
@@ -123,6 +123,12 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
          short: '-M MESSAGE',
          long: '--message MESSAGE',
          description: 'A custom error MESSAGE'
+
+  option :ignore_severity,
+         long: '--ignore-severity',
+         description: 'Ignore severities, all non-ok will count for critical, critical_count, warning and warning_count option',
+         boolean: true,
+         default: false
 
   def api_request(resource)
     verify_mode = OpenSSL::SSL::VERIFY_PEER
@@ -208,21 +214,25 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
   end
 
   def compare_thresholds(aggregate)
-    percent_non_zero = (100 - (aggregate[:ok].to_f / aggregate[:total].to_f) * 100).to_i
-    message = ''
-    if aggregate[:outputs]
-      aggregate[:outputs].each do |output, count|
-        message << "\n" + output.to_s if count == 1
+    message = config[:message] || 'Number of non-zero results exceeds threshold'
+    message += ' (%d%% %s)'
+    message += "\n" + aggregate[:outputs] if aggregate[:outputs]
+
+    if config[:ignore_severity]
+      percent_non_zero = (100 - (aggregate[:ok].to_f / aggregate[:total].to_f) * 100).to_i
+      if config[:critical] && percent_non_zero >= config[:critical]
+        critical message % [percent_non_zero, 'non-zero']
+      elsif config[:warning] && percent_non_zero >= config[:warning]
+        warning message % [percent_non_zero, 'non-zero']
       end
     else
-      message = config[:message] || 'Number of non-zero results exceeds threshold'
-      message += " (#{percent_non_zero}% non-zero)"
-    end
-
-    if config[:critical] && percent_non_zero >= config[:critical]
-      critical message
-    elsif config[:warning] && percent_non_zero >= config[:warning]
-      warning message
+      percent_warning = (aggregate[:warning].to_f / aggregate[:total].to_f * 100).to_i
+      percent_critical = (aggregate[:critical].to_f / aggregate[:total].to_f * 100).to_i
+      if config[:critical] && percent_critical >= config[:critical]
+        critical message % [percent_critical, 'critical']
+      elsif config[:warning] && percent_warning >= config[:warning]
+        warning message % [percent_warning, 'warning']
+      end
     end
   end
 
@@ -246,21 +256,26 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
   end
 
   def compare_thresholds_count(aggregate)
-    number_of_nodes_reporting_down = aggregate[:total].to_i - aggregate[:ok].to_i
-    message = ''
-    if aggregate[:outputs]
-      aggregate[:outputs].each do |output, count|
-        message << "\n" + output.to_s if count == 1
+    message = config[:message] || 'Number of nodes down exceeds threshold'
+    message += " (%s out of #{aggregate[:total]} nodes reporting %s)"
+    message += "\n" + aggregate[:outputs] if aggregate[:outputs]
+
+    if config[:ignore_severity]
+      number_of_nodes_reporting_down = aggregate[:total].to_i - aggregate[:ok].to_i
+      if config[:critical_count] && number_of_nodes_reporting_down>= config[:critical_count]
+        critical message % [number_of_nodes_reporting_down, 'not ok']
+      elsif config[:warning_count] && number_of_nodes_reporting_down >= config[:warning_count]
+        warning message % [number_of_nodes_reporting_down, 'not ok']
       end
     else
-      message = config[:message] || 'Number of nodes down exceeds threshold'
-      message += " (#{number_of_nodes_reporting_down} out of #{aggregate[:total]} nodes reporting not ok)"
-    end
+      nodes_reporting_warning = aggregate[:warning].to_i
+      nodes_reporting_critical = aggregate[:critical].to_i
 
-    if config[:critical_count] && number_of_nodes_reporting_down >= config[:critical_count]
-      critical message
-    elsif config[:warning_count] && number_of_nodes_reporting_down >= config[:warning_count]
-      warning message
+      if config[:critical_count] && nodes_reporting_critical >= config[:critical_count]
+        critical message % [nodes_reporting_critical, 'critical']
+      elsif config[:warning_count] && nodes_reporting_warning >= config[:warning_count]
+        warning message % [nodes_reporting_warning, 'warning']
+      end
     end
   end
 


### PR DESCRIPTION
#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Changes the default behaviour to alert with the severity of the aggregated checks. The ignore-severity option allows to ignore the severities and just alert (like before) based on the amount of non-ok.

We need the functionality to only exit with critical when there are enough critical checks. To alert based on non-ok is not enough for us.

I am open for other suggestions to solve this issue.
