### PR TITLE
update the aggregate metric to the latest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- metrics-aggregates.rb: Refactored to support new named aggregates introduced in Sensu 0.24
 
 ## [2.1.0] - 2017-08-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - metrics-aggregates.rb: Refactored to support new named aggregates introduced in Sensu 0.24 (@oba11)
-=======
+
 ### Changed
 - check-stale-results.rb: made invocation of ok more idiomatic (@rbanffy)
 

--- a/bin/metrics-aggregate.rb
+++ b/bin/metrics-aggregate.rb
@@ -24,8 +24,9 @@
 # LICENSE for details.
 
 require 'sensu-plugin/metric/cli'
-require 'rest-client'
 require 'json'
+require 'net/http'
+require 'net/https'
 
 class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :api,
@@ -68,20 +69,18 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Verbose output'
 
   def api_request(resource)
-    request = RestClient::Resource.new(config[:api] + resource, timeout: config[:timeout],
-                                                                user: config[:user],
-                                                                password: config[:password])
-    JSON.parse(request.get, symbolize_names: true)
-  rescue RestClient::ResourceNotFound
-    warning "Resource not found: #{resource}"
+    uri = URI.parse(config[:api])
+    http = Net::HTTP.new(uri.host, uri.port)
+    if uri.scheme == 'https'
+      http.use_ssl = true
+    end
+    req = Net::HTTP::Get.new(resource)
+    r = http.request(req)
+    JSON.parse(r.body)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
-  rescue RestClient::RequestFailed
-    warning 'Request failed'
-  rescue RestClient::RequestTimeout
+  rescue Timeout::Error
     warning 'Connection timed out'
-  rescue RestClient::Unauthorized
-    warning 'Missing or incorrect Sensu API credentials'
   rescue JSON::ParserError
     warning 'Sensu API returned invalid JSON'
   end
@@ -95,27 +94,27 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def get_aggregate(check)
     uri = "/aggregates/#{check}"
-    issued = api_request(uri + "?age=#{config[:age]}")
-    unless issued.empty?
-      issued_sorted = issued.sort
-      time = issued_sorted.pop
-      unless time.nil?
-        uri += "/#{time}"
-        [time, api_request(uri)]
-      else
-        warning "No aggregates older than #{config[:age]} seconds"
-      end
-    else
+    issued = api_request(uri + "?max_age=#{config[:age]}")
+    if issued.empty?
       warning "No aggregates for #{check}"
+    else
+      issued
     end
   end
 
   def run
+    timestamp = Time.now.to_i
     acquire_checks.each do |check|
-      timestamp, aggregate = get_aggregate(check[:check])
-      puts "#{check[:check]} aggregates: #{aggregate}" if config[:debug]
+      aggregate = get_aggregate(check['name'])
+      puts "#{check['name']} aggregates: #{aggregate}" if config[:debug]
       aggregate.each do |result, count|
-        output "#{config[:scheme]}.#{check[:check]}.#{result}", count, timestamp
+        if count.is_a?(Hash)
+          count.each do |x, y|
+            output "#{config[:scheme]}.#{check['name']}.#{x}", y, timestamp
+          end
+        else
+          output "#{config[:scheme]}.#{check['name']}.#{result}", count, timestamp
+        end
       end
     end
     ok


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No, just noticed that the existing metrics doesnt work any longer

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Since the aggregation API change since 0.24, this metrics hasn't been working. This PR updates the metrics plugin to resolve it.

#### Known Compatibility Issues
Wont work with sensu api less than 0.24
