### PR TITLE
use sensu 0.26+ internal client names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
-### Breaking Change
-- handler-sensu.rb: In sensu version [0.26](https://github.com/sensu/sensu/blob/v1.0.0/CHANGELOG.md#features-4) clients create and subscribes to a unique client subscription named after it. It should look like "client:#{client_name}", this changes the fallback from "#{client_name}" to "client:#{client_name}" when the check does not have an attribute of `trigger_on`. (@Ssawa)
+### Changed
+- handler-sensu.rb: In sensu version [0.26](https://github.com/sensu/sensu/blob/v1.0.0/CHANGELOG.md#features-4) clients create and subscribes to a unique client subscription named after it. Adding new internal sensu client name in addition to old defaults keeping backwards compatibility. (@Ssawa)
 
 ## [2.2.1] - 2017-09-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Breaking Change
+- handler-sensu.rb: In sensu version [0.26](https://github.com/sensu/sensu/blob/v1.0.0/CHANGELOG.md#features-4) clients create and subscribes to a unique client subscription named after it. It should look like "client:#{client_name}", this changes the fallback from "#{client_name}" to "client:#{client_name}" when the check does not have an attribute of `trigger_on`. (@Ssawa)
+
 ## [2.2.1] - 2017-09-25
 ### Fixed
 - check-stale-results.rb: Removed broken and unnecessary block argument that stopped the plugin from running (@portertech)

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -89,7 +89,7 @@ class Remediator < Sensu::Handler
 
     remediation_checks = parse_remediations(remediations, occurrences, severity)
 
-    subscribers = @event['check']['trigger_on'] ? @event['check']['trigger_on'] : [client]
+    subscribers = @event['check']['trigger_on'] ? @event['check']['trigger_on'] : ['client:' + client]
     remediation_checks.each do |remediation_check|
       puts "REMEDIATION: Triggering remediation check '#{remediation_check}' "\
            "for #{[client].inspect}"

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -89,7 +89,8 @@ class Remediator < Sensu::Handler
 
     remediation_checks = parse_remediations(remediations, occurrences, severity)
 
-    subscribers = @event['check']['trigger_on'] ? @event['check']['trigger_on'] : ['client:' + client]
+    # at some point we should come back and remove the old default subscription of [client]
+    subscribers = @event['check']['trigger_on'] ? @event['check']['trigger_on'] : ['client:' + client, client]
     remediation_checks.each do |remediation_check|
       puts "REMEDIATION: Triggering remediation check '#{remediation_check}' "\
            "for #{[client].inspect}"


### PR DESCRIPTION
In sensu version [0.26](https://github.com/sensu/sensu/blob/v1.0.0/CHANGELOG.md#features-4) clients create and subscribes to a unique client subscription named after it. It should look like "client:#{client_name}", this changes the fallback from "#{client_name}" to "client:#{client_name}" when the check does not have an attribute of `trigger_on`.

Credit: https://github.com/Ssawa/sensu-plugins-sensu/commit/764ca7b5164689c1f0cc1d534d5bb7008125f5c1

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

closes #31 

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Leverage new built in auto created client (that it auto subscribes to).

#### Known Compatibility Issues
This is a breaking change, for all clients that are < 0.26 you must set `trigger_on` as the default has changed from the client name to an internal client name that it auto subscribes to.