### PR TITLE
Removed broken and unnecessary block argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-stale-results.rb: Removed broken and unnecessary block argument that stopped the plugin from running (@portertech)
 
 ## [2.2.0] - 2017-09-16
 ### Changed

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -60,7 +60,7 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
     end.compact.reverse.join(' ')
   end
 
-  def api_request(method, path, _blk)
+  def api_request(method, path)
     unless settings.key?('api')
       raise 'api.json settings not found.'
     end


### PR DESCRIPTION
The block argument should have been `&blk`. I removed it, as yield() is used, making it unnecessary.