### PR TITLE
Change the subscriber target to 'client:name' and add more info to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Changed
+- handler-sensu.rb: more log info, with creator and reason included in json. Check name information (REMEDIATION:) at sensu server logs. Tested on sensu > 0.29. (@betorvs)
+
 ## [2.2.2] - 2017-09-26
 ### Changed
 - handler-sensu.rb: In sensu version [0.26](https://github.com/sensu/sensu/blob/v1.0.0/CHANGELOG.md#features-4) clients create and subscribes to a unique client subscription named after it. Adding new internal sensu client name in addition to old defaults keeping backwards compatibility. (@Ssawa)

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -133,7 +133,7 @@ class Remediator < Sensu::Handler
   # Issue a check via the API
   def trigger_remediation(check, subscribers)
     api_request(:POST, '/request') do |req|
-      req.body = JSON.dump({'check' => check, 'subscribers' => [subscribers], 'creator' => 'SENSU', 'reason' => 'Try to fix' })
+      req.body = JSON.dump( 'check' => check, 'subscribers' => [subscribers], 'creator' => 'SENSU', 'reason' => 'Try to fix' )
     end
   end
 end

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -92,7 +92,7 @@ class Remediator < Sensu::Handler
     remediation_checks = parse_remediations(remediations, occurrences, severity)
 
     # at some point we should come back and remove the old default subscription of [client]
-    subscribers = trigger_on ? @event['check']['trigger_on'] : "client:#{client}"
+    subscribers = trigger_on ? @event['check']['trigger_on'] : ['client:' + client, client]
     remediation_checks.each do |remediation_check|
       puts "REMEDIATION: Triggering remediation check '#{remediation_check}' "\
            "for #{[client].inspect} #{subscribers}"
@@ -133,7 +133,7 @@ class Remediator < Sensu::Handler
   # Issue a check via the API
   def trigger_remediation(check, subscribers)
     api_request(:POST, '/request') do |req|
-      req.body = JSON.dump('check' => check, 'subscribers' => [subscribers], 'creator' => 'SENSU', 'reason' => 'Try to fix')
+      req.body = JSON.dump('check' => check, 'subscribers' => [subscribers], 'creator' => 'sensu-plugins-sensu', 'reason' => 'Auto remediation triggered')
     end
   end
 end

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -133,7 +133,7 @@ class Remediator < Sensu::Handler
   # Issue a check via the API
   def trigger_remediation(check, subscribers)
     api_request(:POST, '/request') do |req|
-      req.body = JSON.dump( 'check' => check, 'subscribers' => [subscribers], 'creator' => 'SENSU', 'reason' => 'Try to fix' )
+      req.body = JSON.dump('check' => check, 'subscribers' => [subscribers], 'creator' => 'SENSU', 'reason' => 'Try to fix')
     end
   end
 end


### PR DESCRIPTION
line 95: change to use client:name to subscribe the check remediation
line 136: change the json to include creator info and reason and use subscriber with []

## Pull Request Checklist

**Is this in reference to an existing issue?**
No.

#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose

Add more info into log, and change the target subscriber to client:name.

#### Known Compatibility Issues

Tested on sensu 0.29 or higher.