### PR TITLE
Json order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- update the require order for json so that it comes after sensu_plugin (@barryorourke)
 
 ## [2.3.0] - 2017-10-03
 ### Changed

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -6,9 +6,9 @@
 #
 
 require 'net/http'
-require 'json'
 require 'sensu-plugin/utils'
 require 'sensu-plugin/check/cli'
+require 'json'
 require 'chronic_duration'
 
 class CheckStaleResults < Sensu::Plugin::Check::CLI


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

To resolve ordering issue that results in;

```
[root@sensu ~]# /opt/sensu/embedded/bin/ruby /opt/sensu/embedded/bin/check-stale-results.rb -v
/opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:2278:in `check_version_conflict': can't activate json-1.8.6, already activated json-2.0.2 (Gem::LoadError)
        from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1404:in `activate'
        from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:89:in `block in require'
        from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:88:in `each'
        from /opt/sensu/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:88:in `require'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-sensu-2.3.0/bin/check-stale-results.rb:9:in `<top (required)>'
        from /opt/sensu/embedded/bin/check-stale-results.rb:22:in `load'
        from /opt/sensu/embedded/bin/check-stale-results.rb:22:in `<main>'
```

#### Known Compatibility Issues
