### PR TITLE
Removing brackets that break remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Changed
+### Changed - 2017-12-11
 - Removed brackets that were added around `subscribers` in the `trigger_remediation` method to fix remediation
 
 ## [2.4.0] - 2017-10-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Changed - 2017-12-11
-- Removed brackets that were added around `subscribers` in the `trigger_remediation` method to fix remediation
+
+### Fixed
+- Removed brackets that were added around `subscribers` in the `trigger_remediation` method in #15. This resulted in a successful submission with an HTTP 202, however as this resulted in the subscribers key being an array of arrays which meant that the remediation never was actually scheduled. This fixes it by doing a couple of things, first we remove the extra brackets therefore solving the problem. That being said I decided to add some additional validation of the data to ensure that minimally what is being passed in is an array and the first element is a string, if that is not the case we either error out when unable to determine a fix with a helpful message or in the case of nested arrays attempt to flatten them. (@drhey) (@majormoses)
 
 ## [2.4.0] - 2017-10-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Removed brackets that were added around `subscribers` in the `trigger_remediation` method to fix remediation
 
 ## [2.4.0] - 2017-10-12
 ### Added

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -132,8 +132,20 @@ class Remediator < Sensu::Handler
 
   # Issue a check via the API
   def trigger_remediation(check, subscribers)
+    if subscribers.class != Array
+      p "subscribers: #{subscribers} must be an array"
+      exit 3
+    elsif subscribers.first.class == Array
+      subscribers.flatten
+      p "subscribers: #{subscribers} must be a flat array of strings, we auto flattened: #{subscribers}"
+    end
     api_request(:POST, '/request') do |req|
-      req.body = JSON.dump('check' => check, 'subscribers' => subscribers, 'creator' => 'sensu-plugins-sensu', 'reason' => 'Auto remediation triggered')
+      req.body = JSON.dump(
+        'check' => check,
+        'subscribers' => subscribers,
+        'creator' => 'sensu-plugins-sensu',
+        'reason' => 'Auto remediation triggered'
+      )
     end
   end
 end

--- a/bin/handler-sensu.rb
+++ b/bin/handler-sensu.rb
@@ -133,7 +133,7 @@ class Remediator < Sensu::Handler
   # Issue a check via the API
   def trigger_remediation(check, subscribers)
     api_request(:POST, '/request') do |req|
-      req.body = JSON.dump('check' => check, 'subscribers' => [subscribers], 'creator' => 'sensu-plugins-sensu', 'reason' => 'Auto remediation triggered')
+      req.body = JSON.dump('check' => check, 'subscribers' => subscribers, 'creator' => 'sensu-plugins-sensu', 'reason' => 'Auto remediation triggered')
     end
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

This is in reference to issue #50 

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

N/A

#### Purpose

The brackets that were added around `subscribers` in req.body (within the trigger_remediation method) result in remediation not working. The API call is issued and returns a 202, but further investigation shows that double brackets appear around the subscribers resulting in no remediation being executed on afflicted hosts.

#### Known Compatibility Issues

None
