### PR TITLE
support multiple metric output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 ### Changed
 - `bin/metrics-*`: Used `Sensu::Plugin::Metric::CLI::Generic` class instead of Graphite specific class for metrics. (@bergerx)
+### Breaking Change
+- bumped dependency of `sensu-plugin` to 2.x you can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29)
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 ### Changed
-- bin/metrics-*: Used `Sensu::Plugin::Metric::CLI::Generic` class instead of Graphite specific class for metrics.
+- `bin/metrics-*`: Used `Sensu::Plugin::Metric::CLI::Generic` class instead of Graphite specific class for metrics. (@bergerx)
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- bin/metrics-*: Used `Sensu::Plugin::Metric::CLI::Generic` class instead of Graphite specific class for metrics.
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/bin/metrics-aggregate.rb
+++ b/bin/metrics-aggregate.rb
@@ -28,7 +28,7 @@ require 'json'
 require 'net/http'
 require 'net/https'
 
-class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
+class AggregateMetrics < Sensu::Plugin::Metric::CLI::Generic
   option :api,
          short: '-a URL',
          long: '--api URL',
@@ -60,9 +60,14 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
          proc: proc(&:to_i)
 
   option :scheme,
-         description: 'Metric naming scheme',
+         description: 'Metric naming scheme for graphite format',
          long: '--scheme SCHEME',
          default: "#{Socket.gethostname}.sensu.aggregates"
+
+  option :measurement,
+         description: 'Measurement for influxdb format',
+         long: '--measurement MEASUREMENT',
+         default: 'sensu.aggregates'
 
   option :debug,
          long: '--debug',
@@ -76,12 +81,12 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
     end
     req = Net::HTTP::Get.new(resource)
     r = http.request(req)
-    JSON.parse(r.body)
+    ::JSON.parse(r.body)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
   rescue Timeout::Error
     warning 'Connection timed out'
-  rescue JSON::ParserError
+  rescue ::JSON::ParserError
     warning 'Sensu API returned invalid JSON'
   end
 
@@ -112,10 +117,28 @@ class AggregateMetrics < Sensu::Plugin::Metric::CLI::Graphite
         # maintain backwards compatibility with 0.23 and newer versions.
         if count.is_a?(Hash)
           count.each do |x, y|
-            output "#{config[:scheme]}.#{check['name']}.#{x}", y, timestamp
+            output metric_name: x,
+                   value: y,
+                   graphite_metric_path: "#{config[:scheme]}.#{check['name']}.#{x}",
+                   statsd_metric_name: "#{config[:scheme]}.#{check['name']}.#{x}",
+                   influxdb_measurement: config[:measurement],
+                   tags: {
+                     check: check['name'],
+                     host: Socket.gethostname
+                   },
+                   timestamp: timestamp
           end
         else
-          output "#{config[:scheme]}.#{check['name']}.#{result}", count, timestamp
+          output metric_name: result,
+                 value: count,
+                 graphite_metric_path: "#{config[:scheme]}.#{check['name']}.#{result}",
+                 statsd_metric_name: "#{config[:scheme]}.#{check['name']}.#{result}",
+                 influxdb_measurement: config[:measurement],
+                 tags: {
+                   check: check['name'],
+                   host: Socket.gethostname
+                 },
+                 timestamp: timestamp
         end
       end
     end

--- a/bin/metrics-aggregate.rb
+++ b/bin/metrics-aggregate.rb
@@ -5,11 +5,14 @@
 # Walks the /aggregates API to return metrics for
 # the aggregated output states of each check.
 #
+# sensu.aggregates.some_aggregated_check.clients 1 1380251999
+# sensu.aggregates.some_aggregated_check.checks 125 1380251999
 # sensu.aggregates.some_aggregated_check.ok 125 1380251999
 # sensu.aggregates.some_aggregated_check.warning  0 1380251999
 # sensu.aggregates.some_aggregated_check.critical 0 1380251999
 # sensu.aggregates.some_aggregated_check.unknown  0 1380251999
 # sensu.aggregates.some_aggregated_check.total  125 1380251999
+# sensu.aggregates.some_aggregated_check.stale  0 1380251999
 # ===
 #
 # Authors

--- a/bin/metrics-events.rb
+++ b/bin/metrics-events.rb
@@ -4,9 +4,11 @@
 #
 # Use the /events API to collect events and their severity.
 #
-# sensu.events.total 2 1234535436
-# sensu.events.warning 0 1234535436
-# sensu.events.critical 0 1234535436
+# sensu.events.total 156 1518300288
+# sensu.events.warning 6 1518300288
+# sensu.events.critical 64 1518300288
+# sensu.events.status.3 79 1518300288
+# sensu.events.status.127 7 1518300288
 #
 # ===
 #
@@ -23,7 +25,7 @@ require 'sensu-plugin/metric/cli'
 require 'rest-client'
 require 'json'
 
-class AggregateMetrics < Sensu::Plugin::Metric::CLI::Generic
+class EventMetrics < Sensu::Plugin::Metric::CLI::Generic
   option :api,
          short: '-a URL',
          long: '--api URL',

--- a/sensu-plugins-sensu.gemspec
+++ b/sensu-plugins-sensu.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsSensu::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.4'
   s.add_runtime_dependency 'rest-client',       '1.8.0'
   s.add_runtime_dependency 'chronic_duration',  '0.10.6'
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets
**Not needed**

- [ ] Binstubs are created if needed
**Not needed**

- [x] RuboCop passes

- [x] Existing tests pass
No tests written for this package, and writing tests for `bin/*` files is not straightforward. You can see my own tests results against our sensu server here: https://gist.github.com/bergerx/3d026a6888006914bc068b01dd6b83d3

#### Purpose

Following the sensu-plugins/sensu-plugin#185 released in [sensu-plugin 2.4.0](https://rubygems.org/gems/sensu-plugin/versions/2.4.0) this change introduces the multiple metrics output format support.

#### Known Compatibility Issues

Previously the `bin/metric-*` scripts were only supporting graphite format, now they support various output formats but the default behaviour and output stays same, so the change is backward compatible.

Bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29)