### PR TITLE
Add option to use ssl on stale checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 ### Changed
-- check-stale-results.rb: support plugin configuration to set the desired protocol (http/https), refactored to use a URI constructed based on plugin configuration 
+- check-stale-results.rb: support https protocol via api/host declaration
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 ### Changed
-- check-stale-results.rb: added option (--protocol) to support both http & https communication when running stale checks.
+- check-stale-results.rb: support plugin configuration to set the desired protocol (http/https), refactored to use a URI constructed based on plugin configuration 
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 ### Changed
-- check-stale-results.rb: added option (--ssl) to support ssl communication when running stale checks.
+- check-stale-results.rb: added option (--protocol) to support both http & https communication when running stale checks.
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- check-stale-results.rb: added option (--ssl) to support ssl communication when running stale checks.
 
 ## [2.4.1] - 2018-01-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage: check-stale-results.rb (options)
     -s, --stale <TIME>               Elapsed time to consider a check result result (default: 1d)
     -v, --verbose                    Be verbose
     -w, --warn <COUNT>               Warn if number of stale check results exceeds COUNT (default: 1)
-        --ssl                        Use ssl
+    -p, --protocol <PROTOCOL>        Protocol to be used for communication (http/https)
 ```
 
 the --stale command line option accepts elapsed times formatted as documented in https://github.com/hpoydar/chronic_duration.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Usage: check-stale-results.rb (options)
     -s, --stale <TIME>               Elapsed time to consider a check result result (default: 1d)
     -v, --verbose                    Be verbose
     -w, --warn <COUNT>               Warn if number of stale check results exceeds COUNT (default: 1)
+        --ssl                        Use ssl
 ```
 
 the --stale command line option accepts elapsed times formatted as documented in https://github.com/hpoydar/chronic_duration.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Usage: check-stale-results.rb (options)
     -s, --stale <TIME>               Elapsed time to consider a check result result (default: 1d)
     -v, --verbose                    Be verbose
     -w, --warn <COUNT>               Warn if number of stale check results exceeds COUNT (default: 1)
-    -p, --protocol <PROTOCOL>        Protocol to be used for communication (http/https)
 ```
 
 the --stale command line option accepts elapsed times formatted as documented in https://github.com/hpoydar/chronic_duration.

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -61,12 +61,16 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
     end.compact.reverse.join(' ')
   end
 
+  def get_uri(path)
+    protocol = (settings['api'].key?('protocol') ? settings['api']['protocol'] : 'http')
+    uri = URI(protocol + '://' + settings['api']['host'] + ':' + settings['api']['port'].to_s + path)
+  end
+
   def api_request(path)
     unless settings.key?('api')
       raise 'api.json settings not found.'
     end
-    protocol = (settings['api'].key?('protocol') ? settings['api']['protocol'] : 'http')
-    uri = URI(protocol + '://' + settings['api']['host'] + ':' + settings['api']['port'].to_s + path)
+    uri = get_uri(path)
     response = nil
     Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
       request = Net::HTTP::Get.new uri

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -42,11 +42,12 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: nil
 
-  option :ssl,
-         description: 'Use SSL',
-         long: '--ssl',
-         boolean: true,
-         default: false
+  option :protocol,
+         description: 'Protocol for communication http/https',
+         short: '-p PROTOCOL',
+         long: '--protocol PROTOCOL',
+         default: 'http',
+         in: %w(http https)
 
   def initialize
     super
@@ -72,7 +73,7 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
     end
     http = Net::HTTP.new(settings['api']['host'], settings['api']['port'])
     req = net_http_req_class(method).new(path)
-    http.use_ssl = true if config[:ssl]
+    http.use_ssl = true if config[:protocol] == 'https'
     if settings['api']['user'] && settings['api']['password']
       req.basic_auth(settings['api']['user'], settings['api']['password'])
     end

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -42,6 +42,12 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: nil
 
+  option :ssl,
+         description: 'Use SSL',
+         long: '--ssl',
+         boolean: true,
+         default: false
+
   def initialize
     super
 
@@ -66,6 +72,7 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
     end
     http = Net::HTTP.new(settings['api']['host'], settings['api']['port'])
     req = net_http_req_class(method).new(path)
+    http.use_ssl = true if config[:ssl]
     if settings['api']['user'] && settings['api']['password']
       req.basic_auth(settings['api']['user'], settings['api']['password'])
     end

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -64,6 +64,7 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
   def get_uri(path)
     protocol = (settings['api'].key?('protocol') ? settings['api']['protocol'] : 'http')
     uri = URI(protocol + '://' + settings['api']['host'] + ':' + settings['api']['port'].to_s + path)
+    uri
   end
 
   def api_request(path)


### PR DESCRIPTION
Added option (--ssl) to use SSL communication when running check-stale-results.rb

## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Add option to use ssl on stale checks

#### Known Compatibility Issues
