### PR TITLE
Update stale result plugins to paginate API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- bumped dependency of `sensu-plugin` to `~> 2.6` to provide paginated HTTP get (@cwjohnston)
+- check-stale-results.rb: use paginated HTTP get (@cwjohnston)
+- handler-purge-stale-results.rb: use paginated HTTP get (@cwjohnston)
 
 ## [4.0.0] - 2018-07-18
 ### Security

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -89,7 +89,6 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
   end
 
   def results
-    res = []
     res = paginated_get('/results')
     res
   end

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -90,8 +90,7 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
 
   def results
     res = []
-    req = api_request(:GET, '/results')
-    res = JSON.parse(req.body) if req&.code == '200'
+    res = paginated_get('/results')
     res
   end
 

--- a/bin/handler-purge-stale-results.rb
+++ b/bin/handler-purge-stale-results.rb
@@ -37,7 +37,6 @@ class HandlerPurgeStaleResults < Sensu::Handler
          required: true
 
   def results
-    res = []
     res = paginated_get('/results')
     res
   end

--- a/bin/handler-purge-stale-results.rb
+++ b/bin/handler-purge-stale-results.rb
@@ -38,8 +38,7 @@ class HandlerPurgeStaleResults < Sensu::Handler
 
   def results
     res = []
-    req = api_request(:GET, '/results')
-    res = JSON.parse(req.body) if req&.code == '200'
+    res = paginated_get('/results')
     res
   end
 

--- a/sensu-plugins-sensu.gemspec
+++ b/sensu-plugins-sensu.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_runtime_dependency 'chronic_duration',  '0.10.6'
   s.add_runtime_dependency 'rest-client', '1.8.0'
-  s.add_runtime_dependency 'sensu-plugin', '~> 2.5'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.6'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Alleviate timeouts encountered by users with a large number of check results when using check-stale-results.rb and/or handler-purge-stale-results.rb.

* Update the minimum version of sensu-plugin to ~> 2.6 
* Update check-stale-results.rb and handler-purge-stale-results.rb plugins to make use of the `paginated_get` method

#### Context

As a matter of good hygiene, many Sensu users depend on the check-stale-results.rb and handler-purge-stale-results.rb plugins in this collection to detect and purge stale check results. 

Users with a large number of clients and/or checks may have a very large number of check results to process, which can result in API request timeouts in these plugins.

Sensu 1.4 adds support for paginating API requests using `limit` and `offset` query parameters and sensu-plugin 2.6.0 adds a `paginated_get` method for using these parameters to iteratively request data from the Sensu API.

Using API request pagination helps to reduce the likelihood that check or handler execution will hit a timeout while waiting for API responses.
