### PR TITLE
adding read timeout for http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Changed
+- check-stale-results.rb: added an option to pass read_timeout for http request.
+
 ## [4.1.0] - 2018-08-28
 ### Changed
 - bumped dependency of `sensu-plugin` to `~> 2.6` to provide paginated HTTP get (@cwjohnston)

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -45,6 +45,13 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: nil
 
+  option :timeout,
+         description: 'Max timeout for http request call',
+         short: '-t <COUNT>',
+         long: '--timeout <COUNT>',
+         proc: proc(&:to_i),
+         default: 60
+
   def initialize
     super
 
@@ -78,7 +85,7 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
       HEREDOC
     end
     uri = get_uri(path)
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: config[:timeout]) do |http|
       request = net_http_req_class(method).new(path)
       if settings['api']['user'] && settings['api']['password']
         request.basic_auth(settings['api']['user'], settings['api']['password'])

--- a/bin/check-stale-results.rb
+++ b/bin/check-stale-results.rb
@@ -46,9 +46,9 @@ class CheckStaleResults < Sensu::Plugin::Check::CLI
          default: nil
 
   option :timeout,
-         description: 'Max timeout for http request call',
-         short: '-t <COUNT>',
-         long: '--timeout <COUNT>',
+         description: 'read timeout for http request',
+         short: '-t <TIME>',
+         long: '--timeout <TIME>',
          proc: proc(&:to_i),
          default: 60
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass



#### Purpose
to allow users to pass in read_timeout for http request.

#### Known Compatibility Issues
